### PR TITLE
Add free automated flake8 testing on all pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: python
+cache: pip
+python:
+    - 2.7.13
+    - 3.6
+install:
+    - pip install flake8
+before_script:
+    # stop the build if there are Python syntax errors or undefined names
+    - time flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+    - time flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script:
+    - true  # add other tests here
+notifications:
+    on_success: change
+    on_failure: always


### PR DESCRIPTION
This can help us find a fix incompatibilities.  The owner of the this repo would need to go to https://travis-ci.org/profile and flip the repository switch on to enable free automated flake8 testing on each pull request.  #44 solves many of these issues.

```
flake8 testing of https://github.com/chiphuyen/stanford-tensorflow-tutorials on Python 2.7.13

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__

./assignments/style_transfer_starter/style_transfer.py:119:38: F821 undefined name 'total_loss'
    return content_loss, style_loss, total_loss
                                     ^

./assignments/style_transfer_starter/style_transfer.py:158:29: F821 undefined name 'gen_image'
                gen_image = gen_image + MEAN_PIXELS
                            ^

./assignments/style_transfer_starter/style_transfer.py:159:17: F821 undefined name 'writer'
                writer.add_summary(summary, global_step=index)
                ^

./assignments/style_transfer_starter/style_transfer.py:159:36: F821 undefined name 'summary'
                writer.add_summary(summary, global_step=index)
                                   ^

./assignments/style_transfer_starter/style_transfer.py:161:49: F821 undefined name 'total_loss'
                print('   Loss: {:5.1f}'.format(total_loss))
                                                ^

./examples/02_simple_tf.py:30:10: F821 undefined name 'shape'
tf.zeros(shape, dtype=tf.float32, name=None)
         ^

./examples/03_linear_regression_starter.py:58:18: F821 undefined name 'l'
			total_loss += l
                 ^

./examples/03_logistic_regression_mnist_starter.py:68:18: F821 undefined name 'loss_batch'
			total_loss += loss_batch
                 ^

./examples/03_logistic_regression_mnist_starter.py:76:24: F821 undefined name 'logits'
	preds = tf.nn.softmax(logits)
                       ^

./examples/03_logistic_regression_mnist_starter.py:77:58: F821 undefined name 'Y'
	correct_preds = tf.equal(tf.argmax(preds, 1), tf.argmax(Y, 1))
                                                         ^

./examples/03_logistic_regression_mnist_starter.py:85:52: F821 undefined name 'X'
		accuracy_batch = sess.run([accuracy], feed_dict={X: X_batch, Y:Y_batch}) 
                                                   ^

./examples/03_logistic_regression_mnist_starter.py:85:64: F821 undefined name 'Y'
		accuracy_batch = sess.run([accuracy], feed_dict={X: X_batch, Y:Y_batch}) 
                                                               ^

./examples/04_word2vec_starter.py:83:27: F821 undefined name 'loss_batch'
            total_loss += loss_batch
                          ^

./examples/07_convnet_mnist_starter.py:88:4: E999 IndentationError: expected an indented block
with tf.variable_scope('conv2') as scope:
   ^

./examples/cgru/custom_getter.py:2:2: E999 IndentationError: unexpected indent
  def testGetterThatCreatesTwoVariablesAndSumsThem(self):
 ^

./examples/cgru/data_reader.py:62:8: F821 undefined name 'tf'
  with tf.name_scope("examples_queue"):
       ^

./examples/cgru/data_reader.py:64:29: F821 undefined name 'tf'
    _, example_serialized = tf.contrib.slim.parallel_reader.parallel_read(
                            ^

./examples/cgru/data_reader.py:65:23: F821 undefined name 'tf'
        data_sources, tf.TFRecordReader, shuffle=training,
                      ^

./examples/cgru/data_reader.py:70:18: F821 undefined name 'tf'
          field: tf.contrib.slim.tfexample_decoder.Tensor(field)
                 ^

./examples/cgru/data_reader.py:74:15: F821 undefined name 'tf'
    decoder = tf.contrib.slim.tfexample_decoder.TFExampleDecoder(
              ^

./examples/cgru/data_reader.py:120:8: F821 undefined name 'tf'
  with tf.name_scope("batch_examples"):
       ^

./examples/cgru/data_reader.py:124:20: F821 undefined name 'tf'
      max_length = tf.maximum(max_length, tf.shape(v)[0])
                   ^

./examples/cgru/data_reader.py:124:43: F821 undefined name 'tf'
      max_length = tf.maximum(max_length, tf.shape(v)[0])
                                          ^

./examples/cgru/data_reader.py:125:20: F821 undefined name 'tf'
    (_, outputs) = tf.contrib.training.bucket_by_sequence_length(
                   ^

./examples/cgru/my_layers.py:3:8: F821 undefined name 'tf'
  with tf.name_scope("saturating_sigmoid", [x]):
       ^

./examples/cgru/my_layers.py:4:9: F821 undefined name 'tf'
    y = tf.sigmoid(x)
        ^

./examples/cgru/my_layers.py:5:12: F821 undefined name 'tf'
    return tf.minimum(1.0, tf.maximum(0.0, 1.2 * y - 0.1))
           ^

./examples/cgru/my_layers.py:5:28: F821 undefined name 'tf'
    return tf.minimum(1.0, tf.maximum(0.0, 1.2 * y - 0.1))
                           ^

./examples/cgru/my_layers.py:10:8: F821 undefined name 'tf'
  with tf.variable_scope(name, default_name="embedding",
       ^

./examples/cgru/my_layers.py:12:21: F821 undefined name 'tf'
    embedding_var = tf.get_variable("kernel", [vocab_size, dense_size])
                    ^

./examples/cgru/my_layers.py:13:12: F821 undefined name 'tf'
    return tf.gather(embedding_var, x)
           ^

./examples/cgru/my_layers.py:21:12: F821 undefined name 'tf'
    return tf.layers.conv1d(args, filters, kernel_size,
           ^

./examples/cgru/my_layers.py:23:34: F821 undefined name 'tf'
                bias_initializer=tf.constant_initializer(bias_start), name=name)
                                 ^

./examples/cgru/my_layers.py:25:8: F821 undefined name 'tf'
  with tf.variable_scope(name, default_name="conv_gru",
       ^

./examples/cgru/my_layers.py:29:17: F821 undefined name 'tf'
    candidate = tf.tanh(do_conv(reset * x, "candidate", 0.0, padding))
                ^

./examples/cgru/neural_gpu_v3.py:3:8: F821 undefined name 'tf'
  with tf.variable_scope(name, "neural_gpu"):
       ^

./examples/cgru/neural_gpu_v3.py:5:18: F821 undefined name 'common_layers'
    emb_inputs = common_layers.embedding(
                 ^

./examples/cgru/neural_gpu_v3.py:9:11: F821 undefined name 'tf'
      x = tf.nn.dropout(state, 1.0 - hparams.dropout)
          ^

./examples/cgru/neural_gpu_v3.py:11:13: F821 undefined name 'common_layers'
        x = common_layers.conv_gru(
            ^

./examples/cgru/neural_gpu_v3.py:13:14: F821 undefined name 'tf'
      return tf.where(inp == 0, state, x)  # No-op where inp is just padding=0.
             ^

./examples/cgru/neural_gpu_v3.py:15:13: F821 undefined name 'tf'
    final = tf.foldl(step, tf.transpose(inputs, [1, 0]),
            ^

./examples/cgru/neural_gpu_v3.py:15:28: F821 undefined name 'tf'
    final = tf.foldl(step, tf.transpose(inputs, [1, 0]),
                           ^

./examples/cgru/neural_gpu_v3.py:18:12: F821 undefined name 'common_layers'
    return common_layers.conv(final, hparams.vocab_size, 3, padding="same")
           ^

./examples/cgru/neural_gpu_v3.py:23:8: F821 undefined name 'tf'
  with tf.name_scope("mixed_curriculum"):
       ^

./examples/cgru/neural_gpu_v3.py:24:21: F821 undefined name 'tf'
    inputs_length = tf.to_float(tf.shape(inputs)[1])
                    ^

./examples/cgru/neural_gpu_v3.py:24:33: F821 undefined name 'tf'
    inputs_length = tf.to_float(tf.shape(inputs)[1])
                                ^

./examples/cgru/neural_gpu_v3.py:25:19: F821 undefined name 'tf'
    used_length = tf.cond(tf.less(tf.random_uniform([]),
                  ^

./examples/cgru/neural_gpu_v3.py:25:27: F821 undefined name 'tf'
    used_length = tf.cond(tf.less(tf.random_uniform([]),
                          ^

./examples/cgru/neural_gpu_v3.py:25:35: F821 undefined name 'tf'
    used_length = tf.cond(tf.less(tf.random_uniform([]),
                                  ^

./examples/cgru/neural_gpu_v3.py:27:35: F821 undefined name 'tf'
                          lambda: tf.constant(0.0),
                                  ^

./examples/cgru/neural_gpu_v3.py:29:12: F821 undefined name 'tf'
    step = tf.to_float(tf.contrib.framework.get_global_step())
           ^

./examples/cgru/neural_gpu_v3.py:29:24: F821 undefined name 'tf'
    step = tf.to_float(tf.contrib.framework.get_global_step())
                       ^

./examples/cgru/neural_gpu_v3.py:36:8: F821 undefined name 'tf'
  with tf.name_scope("neural_gpu_with_curriculum"):
       ^

./examples/cgru/neural_gpu_v3.py:38:27: F821 undefined name 'tf'
    is_training = mode == tf.contrib.learn.ModeKeys.TRAIN
                          ^

./examples/cgru/neural_gpu_v3.py:39:19: F821 undefined name 'tf'
    should_skip = tf.logical_and(is_training, mixed_curriculum(inputs, hparams))
                  ^

./examples/cgru/neural_gpu_v3.py:40:19: F821 undefined name 'tf'
    final_shape = tf.concat([tf.shape(inputs),
                  ^

./examples/cgru/neural_gpu_v3.py:40:30: F821 undefined name 'tf'
    final_shape = tf.concat([tf.shape(inputs),
                             ^

./examples/cgru/neural_gpu_v3.py:41:30: F821 undefined name 'tf'
                             tf.constant([hparams.vocab_size])], axis=0)
                             ^

./examples/cgru/neural_gpu_v3.py:42:15: F821 undefined name 'tf'
    outputs = tf.cond(should_skip,
              ^

./examples/cgru/neural_gpu_v3.py:43:31: F821 undefined name 'tf'
                      lambda: tf.zeros(final_shape),
                              ^

./examples/cgru/neural_gpu_v3.py:50:10: F821 undefined name 'tf'
  return tf.HParams(batch_size=32,
         ^

./examples/cgru/neural_gpu_v3.py:71:13: F821 undefined name 'common_hparams'
  hparams = common_hparams.basic_params1()
            ^

2     E999 IndentationError: expected an indented block
60    F821 undefined name 'total_loss'
```