### PR TITLE
Update 03_linreg_starter.py

### DIFF
--- a/examples/03_linreg_starter.py
+++ b/examples/03_linreg_starter.py
@@ -68,8 +68,8 @@ with tf.Session() as sess:
         for x, y in data:
             # Execute train_op and get the value of loss.
             # Don't forget to feed in data for placeholders
-            _, loss = ########## TO DO ############
-            total_loss += loss
+            _, l = ########## TO DO ############
+            total_loss += l
 
         print('Epoch {0}: {1}'.format(i, total_loss/n_samples))
 


### PR DESCRIPTION
Bug: Loss redefined twice for different variables
Fix: The second loss variable is renamed